### PR TITLE
Optimized the normalize search function...

### DIFF
--- a/src/js/track.js
+++ b/src/js/track.js
@@ -44,7 +44,29 @@ Track.prototype.getSelectedSong = function() {
 };
 
 Track.prototype.normalizeSearchQuery = function(query) {
-	var normalized = query;
+	var removeableTags = ["official music video", "lyric video",  "out now",  "cover art",  "official video", "hd", "hq", "lyrics", "radio edit", "radio mix"];
+
+	var normalized = query.toLowerCase(); // let's convert the title to lowercase for a better beginning
+
+	angular.forEach(removeableTags, function(value, key) {
+		normalized = normalized.replace(value, ''); // remove founded tag
+	});
+
+	normalized = normalized.replace(/((ft. |& |feat. |and |&amp; |vs | [xX] )(.*?)(?=-))/, ''); // remove featuring artist at the beginning
+	normalized = normalized.replace(/((ft. |& |feat. |and |&amp; |vs | [xX] )(.*))/,'') // remove featuring artist and everything after at the end
+	//normalized = normalized.replace(/['"]+/g, ""); // remove quotation marks
+
+	splitParentheses = normalized.split(/\(([^)]+)\) \(([^)]+)\)/); // split matches like (ft.) (prod.)
+
+	if(splitParentheses.length >= 3) {
+		angular.forEach(splitParentheses, function(value, key) {
+			if(key >= 2) { // remove everything after the second hit
+				normalized = normalized.replace(value, '');
+			}
+		});
+	}
+
+
 	// Remove any genre tags in the formation [genre]
 	// NOTE: This is pretty naive
 	normalized = normalized.replace(/\[(\w*|\s*|\/|-)+\]/gi, '');


### PR DESCRIPTION
to remove  featuring artists and many tags used in the titles like official music video, hd, radio edit, etc.

I finally had some spare time to optimize the normalization of the video titles. I did this with some regex expression which will remove unnecessary tags from the title. It does the following:

- Lowercased the query for a better start
- Removing featuring artists (at the beginning and at the end of a tittle)
- Removing tags ("official music video"," hd", "radio edit", etc.)
- Finding groups of parentheses at the end of title like : (alternative name) (produced by)
which will remove the last group in this case.

With these fixes I was able to cover most of the tracks of my Youtube playlists (almost everything) this was not possible with the live version. It has been tested with various Youtube playlists and some Reddit lists. 